### PR TITLE
mido, onyx, athene: Delete unneeded packages so build will succeed

### DIFF
--- a/patches/device/motorola/athene/0001-Delete-Android.mk-from-cmactions.patch
+++ b/patches/device/motorola/athene/0001-Delete-Android.mk-from-cmactions.patch
@@ -1,0 +1,63 @@
+From df42264f3c60dec070403c789e42ef12ef009a6f Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Thu, 28 Dec 2017 23:13:24 +0100
+Subject: [PATCH] Delete Android.mk from cmactions
+
+Removing it from device.mk doesn't seem to suffice.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ cmactions/Android.mk | 41 -----------------------------------------
+ 1 file changed, 41 deletions(-)
+ delete mode 100644 cmactions/Android.mk
+
+diff --git a/cmactions/Android.mk b/cmactions/Android.mk
+deleted file mode 100644
+index 00cb9da..0000000
+--- a/cmactions/Android.mk
++++ /dev/null
+@@ -1,41 +0,0 @@
+-LOCAL_PATH:= $(call my-dir)
+-include $(CLEAR_VARS)
+-
+-LOCAL_MODULE_TAGS := optional
+-
+-LOCAL_SRC_FILES := $(call all-java-files-under, src)
+-
+-LOCAL_PACKAGE_NAME := CMActions
+-LOCAL_CERTIFICATE := platform
+-LOCAL_PRIVILEGED_MODULE := true
+-
+-LOCAL_STATIC_JAVA_LIBRARIES := \
+-    android-support-v14-preference \
+-    android-support-v7-appcompat \
+-    android-support-v7-preference \
+-    android-support-v7-recyclerview \
+-    org.cyanogenmod.platform.internal
+-
+-LOCAL_PROGUARD_FLAG_FILES := proguard.flags
+-
+-LOCAL_RESOURCE_DIR := \
+-    $(LOCAL_PATH)/res \
+-    $(LOCAL_PATH)/../../../../packages/resources/devicesettings/res \
+-    frameworks/support/v14/preference/res \
+-    frameworks/support/v7/appcompat/res \
+-    frameworks/support/v7/preference/res \
+-    frameworks/support/v7/recyclerview/res
+-
+-LOCAL_AAPT_FLAGS := --auto-add-overlay \
+-    --extra-packages android.support.v14.preference:android.support.v7.appcompat:android.support.v7.preference:android.support.v7.recyclerview
+-
+-ifneq ($(INCREMENTAL_BUILDS),)
+-    LOCAL_PROGUARD_ENABLED := disabled
+-    LOCAL_JACK_ENABLED := incremental
+-endif
+-
+-include frameworks/base/packages/SettingsLib/common.mk
+-
+-include $(BUILD_PACKAGE)
+-
+-include $(call all-makefiles-under,$(LOCAL_PATH))
+-- 
+2.11.0.windows.3
+

--- a/patches/device/motorola/athene/0001-device.mk-Drop-CMActions.patch
+++ b/patches/device/motorola/athene/0001-device.mk-Drop-CMActions.patch
@@ -1,0 +1,28 @@
+From e8861effa74fb660a565db0665749210d7430bc7 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 28 Dec 2017 16:43:52 +0100
+Subject: [PATCH] device.mk: Drop CMActions
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ device.mk | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/device.mk b/device.mk
+index c8635a0..166fa97 100644
+--- a/device.mk
++++ b/device.mk
+@@ -107,10 +107,6 @@ PRODUCT_PACKAGES += \
+     libbson \
+     Snap
+ 
+-# CMActions
+-PRODUCT_PACKAGES += \
+-    CMActions
+-
+ # Display
+ PRODUCT_PACKAGES += \
+     gralloc.msm8952 \
+-- 
+2.13.2.windows.1
+

--- a/patches/device/oneplus/onyx/0001-device.mk-Drop-OnePlusDoze.patch
+++ b/patches/device/oneplus/onyx/0001-device.mk-Drop-OnePlusDoze.patch
@@ -1,0 +1,30 @@
+From 07fa166f1ebc4f053e96b0ce274c4aba74047cbb Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 28 Dec 2017 16:30:56 +0100
+Subject: [PATCH] device.mk: Drop OnePlusDoze
+
+device.mk: Drop OnePlusDoze APK that we don't need anyway.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ device.mk | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/device.mk b/device.mk
+index 9a8936f..ef7732a 100644
+--- a/device.mk
++++ b/device.mk
+@@ -108,10 +108,6 @@ PRODUCT_PACKAGES += \
+     librmnetctl \
+     rmnetcli
+ 
+-# Doze
+-PRODUCT_PACKAGES += \
+-    OneplusDoze
+-
+ # Graphics
+ PRODUCT_PACKAGES += \
+     copybit.msm8974 \
+-- 
+2.13.2.windows.1
+

--- a/patches/device/oneplus/onyx/0001-onyx-doze-Remove-Android.mk.patch
+++ b/patches/device/oneplus/onyx/0001-onyx-doze-Remove-Android.mk.patch
@@ -1,0 +1,60 @@
+From 42f5cb6e1b90a48a5ad0d4e6ec17a27ec9d32618 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Fri, 29 Dec 2017 00:30:59 +0100
+Subject: [PATCH] onyx: doze: Remove Android.mk
+
+To prevent building completely since dropping it from device.mk doesn't
+suffice.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ doze/Android.mk | 37 -------------------------------------
+ 1 file changed, 37 deletions(-)
+ delete mode 100644 doze/Android.mk
+
+diff --git a/doze/Android.mk b/doze/Android.mk
+deleted file mode 100644
+index e925730..0000000
+--- a/doze/Android.mk
++++ /dev/null
+@@ -1,37 +0,0 @@
+-LOCAL_PATH:= $(call my-dir)
+-include $(CLEAR_VARS)
+-
+-LOCAL_MODULE_TAGS := optional
+-
+-LOCAL_SRC_FILES := $(call all-java-files-under, src)
+-
+-LOCAL_PACKAGE_NAME := OneplusDoze
+-LOCAL_CERTIFICATE := platform
+-LOCAL_PRIVILEGED_MODULE := true
+-LOCAL_STATIC_JAVA_LIBRARIES := \
+-    android-support-v4 \
+-    android-support-v13 \
+-    android-support-v7-recyclerview \
+-    android-support-v7-preference \
+-    android-support-v7-appcompat \
+-    android-support-v14-preference \
+-    org.cyanogenmod.platform.internal
+-
+-LOCAL_RESOURCE_DIR := \
+-    $(LOCAL_PATH)/res \
+-    $(LOCAL_PATH)/../../../../packages/resources/devicesettings/res \
+-    frameworks/support/v7/preference/res \
+-    frameworks/support/v14/preference/res \
+-    frameworks/support/v7/appcompat/res \
+-    frameworks/support/v7/recyclerview/res
+-
+-LOCAL_AAPT_FLAGS := --auto-add-overlay \
+-    --extra-packages android.support.v7.preference:android.support.v14.preference:android.support.v17.preference:android.support.v7.appcompat:android.support.v7.recyclerview
+-
+-LOCAL_PROGUARD_FLAG_FILES := proguard.flags
+-
+-include frameworks/base/packages/SettingsLib/common.mk
+-
+-include $(BUILD_PACKAGE)
+-
+-include $(call all-makefiles-under,$(LOCAL_PATH))
+-- 
+2.11.0.windows.3
+

--- a/patches/device/oppo/common/0001-common.mk-Drop-com.cyanogenmod.keyhandler.patch
+++ b/patches/device/oppo/common/0001-common.mk-Drop-com.cyanogenmod.keyhandler.patch
@@ -1,0 +1,27 @@
+From 9cccc78755e11563a2089d6efb069c183a181758 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 28 Dec 2017 16:35:09 +0100
+Subject: [PATCH] common.mk: Drop com.cyanogenmod.keyhandler
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ common.mk | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/common.mk b/common.mk
+index 4ae6fd8..f5825bd 100644
+--- a/common.mk
++++ b/common.mk
+@@ -19,8 +19,7 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
+ 
+ # Keyhandler
+ PRODUCT_PACKAGES += \
+-    ConfigPanel \
+-    com.cyanogenmod.keyhandler
++    ConfigPanel
+ 
+ PRODUCT_SYSTEM_SERVER_JARS += com.cyanogenmod.keyhandler
+ 
+-- 
+2.13.2.windows.1
+

--- a/patches/device/oppo/common/0001-oppo-common-keyhandler-Delete-Android.mk.patch
+++ b/patches/device/oppo/common/0001-oppo-common-keyhandler-Delete-Android.mk.patch
@@ -1,0 +1,34 @@
+From 1b905a1720548191daaea7f37f8af4963752bd4c Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Fri, 29 Dec 2017 00:36:56 +0100
+Subject: [PATCH] oppo-common: keyhandler: Delete Android.mk
+
+To prevent building completely since dropping it from common.mk doesn't
+suffice.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ keyhandler/Android.mk | 11 -----------
+ 1 file changed, 11 deletions(-)
+ delete mode 100644 keyhandler/Android.mk
+
+diff --git a/keyhandler/Android.mk b/keyhandler/Android.mk
+deleted file mode 100644
+index 66baa7f..0000000
+--- a/keyhandler/Android.mk
++++ /dev/null
+@@ -1,11 +0,0 @@
+-LOCAL_PATH:= $(call my-dir)
+-
+-include $(CLEAR_VARS)
+-
+-LOCAL_MODULE := com.cyanogenmod.keyhandler
+-LOCAL_SRC_FILES := $(call all-java-files-under,src)
+-LOCAL_MODULE_TAGS := optional
+-LOCAL_DEX_PREOPT := false
+-LOCAL_STATIC_JAVA_LIBRARIES := org.cyanogenmod.platform.internal
+-include $(BUILD_JAVA_LIBRARY)
+-
+-- 
+2.11.0.windows.3
+

--- a/patches/vendor/motorola/0001-athene-Remove-packages-from-athene-vendor.mk.patch
+++ b/patches/vendor/motorola/0001-athene-Remove-packages-from-athene-vendor.mk.patch
@@ -1,0 +1,42 @@
+From 7c6a2eb536d9f8409fec62f843fa450eb6640f1c Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 28 Dec 2017 17:23:55 +0100
+Subject: [PATCH] athene: Remove packages from athene-vendor.mk
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ athene/athene-vendor.mk | 20 +-------------------
+ 1 file changed, 1 insertion(+), 19 deletions(-)
+
+diff --git a/athene/athene-vendor.mk b/athene/athene-vendor.mk
+index c63a4651..814e2155 100644
+--- a/athene/athene-vendor.mk
++++ b/athene/athene-vendor.mk
+@@ -1033,23 +1033,5 @@ PRODUCT_COPY_FILES += \
+ PRODUCT_PACKAGES += \
+     libril \
+     libtime_genoff \
+-    TimeService \
+-    CNEService \
+-    qcrilmsgtunnel \
+-    ims \
+-    colorservice \
+-    imssettings \
+-    imscmlibrary \
+     qcnvitems \
+-    qcrilhook \
+-    AttPhoneExt \
+-    CarrierServices \
+-    CarrierSettingsExt \
+-    ConnMO \
+-    CoreSettingsExt \
+-    DCMO \
+-    DiagMon \
+-    DMService \
+-    SprintDM \
+-    DMConfigUpdateLight \
+-    atfwd
++    qcrilhook
+-- 
+2.13.2.windows.1
+

--- a/patches/vendor/oneplus/0001-onyx-vendor.mk-Drop-APK-s-that-we-don-t-need-anyway.patch
+++ b/patches/vendor/oneplus/0001-onyx-vendor.mk-Drop-APK-s-that-we-don-t-need-anyway.patch
@@ -1,0 +1,31 @@
+From 5cb2d53d86a6850f921454d252fd5f34aa62f2b5 Mon Sep 17 00:00:00 2001
+From: Herrie <Github.com@herrie.org>
+Date: Thu, 21 Dec 2017 09:55:00 +0100
+Subject: [PATCH] onyx-vendor.mk: Drop APK's that we don't need anyway.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ onyx/onyx-vendor.mk | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/onyx/onyx-vendor.mk b/onyx/onyx-vendor.mk
+index 1177fd06..c87a44f0 100644
+--- a/onyx/onyx-vendor.mk
++++ b/onyx/onyx-vendor.mk
+@@ -236,12 +236,7 @@ PRODUCT_COPY_FILES += \
+ PRODUCT_PACKAGES += \
+     libloc_api_v02 \
+     libloc_ds_api \
+-    libTimeService \
+     libmm-abl \
+     libtime_genoff \
+-    TimeService \
+-    shutdownlistener \
+-    qcrilmsgtunnel \
+     ConnectivityExt \
+-    qcnvitems \
+-    qcrilhook
++    qcnvitems 
+-- 
+2.13.2.windows.1
+

--- a/patches/vendor/xiaomi/0001-mido-vendor.mk-Drop-APK-s-that-we-don-t-need-anyway.patch
+++ b/patches/vendor/xiaomi/0001-mido-vendor.mk-Drop-APK-s-that-we-don-t-need-anyway.patch
@@ -1,0 +1,36 @@
+From c9e923b810bea44008e7fd02a08a5dc5c440fe78 Mon Sep 17 00:00:00 2001
+From: Herman van Hazendonk <github.com@herrie.org>
+Date: Thu, 30 Nov 2017 09:56:00 +0100
+Subject: [PATCH] mido-vendor.mk: Drop APK's that we don't need anyway.
+
+Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
+---
+ mido/mido-vendor.mk | 12 ------------
+ 1 file changed, 12 deletions(-)
+
+diff --git a/mido/mido-vendor.mk b/mido/mido-vendor.mk
+index dddbe14a..c0b04492 100644
+--- a/mido/mido-vendor.mk
++++ b/mido/mido-vendor.mk
+@@ -1077,18 +1077,6 @@ PRODUCT_PACKAGES += \
+     libtime_genoff \
+     libts_detected_face_hal \
+     libts_face_beautify_hal \
+-    QtiTelephonyService \
+-    TimeService \
+-    datastatusnotification \
+-    embms \
+-    fastdormancy \
+-    shutdownlistener \
+-    CNEService \
+-    QtiTetherService \
+-    com.qualcomm.location \
+-    qcrilmsgtunnel \
+-    ims \
+-    imssettings \
+     com.qti.location.sdk \
+     qcrilhook \
+     qdcm_calib_data_nt35532_fhd_video_mode_dsi_panel \
+-- 
+2.13.2.windows.1
+


### PR DESCRIPTION
Since these are APK's they're anyway not used and can be removed from build.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>