### PR TITLE
Remove bad values from onyx system.prop

### DIFF
--- a/patches/device/oneplus/onyx/0001-Remove-bad-values-from-system.prop.patch
+++ b/patches/device/oneplus/onyx/0001-Remove-bad-values-from-system.prop.patch
@@ -1,0 +1,28 @@
+From 06f32e5c8d3f09f00b424bcf9acd86d4cde1446e Mon Sep 17 00:00:00 2001
+From: Ian Miller <git@och.me.uk>
+Date: Sun, 17 Jun 2018 20:21:03 +0100
+Subject: [PATCH] Remove bad values from system.prop
+
+---
+ system.prop | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/system.prop b/system.prop
+index 1f46aef..4cced3d 100644
+--- a/system.prop
++++ b/system.prop
+@@ -2,11 +2,6 @@
+ # system.prop for OnePlus X
+ #
+ 
+-ro.build.product=OnePlus
+-ro.product.device=OnePlus
+-ro.build.description=OnePlus
+-ro.build.fingerprint=OnePlus/OnePlus/OnePlus:5.1.1/LMY47V/1441677661:user/release-keys
+-
+ # RIL
+ DEVICE_PROVISIONED=1
+ persist.data.netmgrd.qos.enable=true
+-- 
+2.7.4
+


### PR DESCRIPTION
Correct values get generated when build.prop is created. These ones stick around and only cause problems.